### PR TITLE
BC Data

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
         <h1>Data</h1>
 
         <h2>State Specific data</h2>
-        <p>Washington, Oregon, and Idaho is rich with public data sources. Here's a list of what we've found, with descriptions of datasets of note that are available.</p>
+        <p>Washington, Oregon, Idaho and British Columbia are rich with public data sources. Here's a list of what we've found, with descriptions of datasets of note that are available.</p>
 
         <!--
 
@@ -158,7 +158,16 @@
         </div>
 
         -->
+        <div class="state">
+          <h2>British Columbia</h2>
 
+          <ul>
+            <li>
+              <a href="http://www.data.gov.bc.ca/" target="_blank">data.gov.bc.ca</a>
+            </li>
+          </ul>
+        </div>
+        
         <div class="state">
           <h2>Oregon</h2>
 
@@ -288,6 +297,7 @@
         </div>
       </section>
     </div>
+
 
     <div class="row">
       <section id="resources" class="col-md-8 col-md-offset-2">


### PR DESCRIPTION
This PR contains a change to the **data** section:

* added `http://www.data.gov.bc.ca/` to the new British Columbia section

This resolves #23 