### PR TITLE
Replace Code for Seattle org with Open Seattle

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ layout: default
 
       <h2>Organizations</h2>
       <ul>
-        <li><a href="http://codeforseattle.org/" target="_blank">Code for Seattle</a> – Seattle, Washington</li>
+        <li><a href="http://openseattle.org" target="_blank">Open Seattle</a> – Seattle, Washington</li>
         <li><a href="https://twitter.com/CodeforPortland" target="_blank">Code for Portland</a> – Portland, Oregon</li>
         <li><a href="http://www.spocode.org/" target="_blank">SpoCode</a> – Spokane, Washington</li>
         <li><a href="http://openboise.org" target="_blank">Open Boise</a> – Boise, Idaho</li>


### PR DESCRIPTION
Since the Code for Seattle website is no more and hasn't Open Seattle replaced it, I think?